### PR TITLE
Annotate unmarked defined-term uses and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ assert.deepEqual(
       {use: 'Consideration'}
     ]
   }),
-  []
+  [/* no annotations */]
 )
 
 assert.deepEqual(
@@ -318,6 +318,6 @@ assert.deepEqual(
       {use: 'Term'}
     ]
   }),
-  []
+  [/* no annotations */]
 )
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ var assert = require('assert')
 
 `lint` takes a [Common Form](https://npmjs.com/packages/commonform-validate) argument and returns an array of [Common Form Annotations](https://npmjs.com/packages/commonform-annotations).
 
-# Broken Cross-References
+# Cross-Reference Problems
+
+## Broken Cross-References
 
 ```javascript
 var message = 'The heading "Indemnity" is referenced, but not used.'
@@ -51,7 +53,37 @@ assert.deepEqual(
 )
 ```
 
-# Defined Terms
+## Unmarked Cross-References
+
+```javascript
+assert.deepEqual(
+  lint({
+    content: [
+      {
+        heading: 'Preamble',
+        form: {content: ['This is a preamble.']}
+      },
+      {
+        form: {content: ['Nothing important gets said in Preamble.']}
+      }
+    ]
+  }),
+  [
+    {
+      message: (
+        'The heading "Preamble" is used, ' +
+        'but not marked as a reference.'
+      ),
+      level: 'info',
+      path: ['content', 1, 'form', 'content', 0],
+      source: 'commonform-lint',
+      url: null
+    }
+  ],
+  'notes unmarked reference'
+)
+```
+# Defined-Term Problems
 
 ## Conflicting Definitions
 
@@ -168,41 +200,7 @@ assert.deepEqual(
 )
 ```
 
-# Structurally Sound Forms
-
-```javascript
-assert.deepEqual(
-  lint({
-    content: [
-      {definition: 'Agreement'}, ' ',
-      {definition: 'Consideration'}, ' ',
-      {use: 'Agreement'}, ' ',
-      {use: 'Agreement'}, ' ',
-      {use: 'Consideration'}, ' ',
-      {use: 'Consideration'}
-    ]
-  }),
-  []
-)
-
-assert.deepEqual(
-  lint({
-    content: [
-      {
-        heading: 'Heading',
-        form: {content: ['test']}
-      },
-      {reference: 'Heading'}, ' ',
-      {definition: 'Term'}, ' ',
-      {use: 'Term'}, ' ',
-      {use: 'Term'}
-    ]
-  }),
-  []
-)
-```
-
-# Unmarked Defined Terms
+## Unmarked Defined-Term Uses
 
 ```javascript
 assert.deepEqual(
@@ -290,33 +288,36 @@ assert.deepEqual(
 )
 ```
 
-# Unmarked References
+# Structurally Sound Forms
 
 ```javascript
 assert.deepEqual(
   lint({
     content: [
-      {
-        heading: 'Preamble',
-        form: {content: ['This is a preamble.']}
-      },
-      {
-        form: {content: ['Nothing important gets said in Preamble.']}
-      }
+      {definition: 'Agreement'}, ' ',
+      {definition: 'Consideration'}, ' ',
+      {use: 'Agreement'}, ' ',
+      {use: 'Agreement'}, ' ',
+      {use: 'Consideration'}, ' ',
+      {use: 'Consideration'}
     ]
   }),
-  [
-    {
-      message: (
-        'The heading "Preamble" is used, ' +
-        'but not marked as a reference.'
-      ),
-      level: 'info',
-      path: ['content', 1, 'form', 'content', 0],
-      source: 'commonform-lint',
-      url: null
-    }
-  ],
-  'notes unmarked reference'
+  []
+)
+
+assert.deepEqual(
+  lint({
+    content: [
+      {
+        heading: 'Heading',
+        form: {content: ['test']}
+      },
+      {reference: 'Heading'}, ' ',
+      {definition: 'Term'}, ' ',
+      {use: 'Term'}, ' ',
+      {use: 'Term'}
+    ]
+  }),
+  []
 )
 ```

--- a/README.md
+++ b/README.md
@@ -289,3 +289,34 @@ assert.deepEqual(
   'does not note unmarked use of defined term within a longer word'
 )
 ```
+
+# Unmarked References
+
+```javascript
+assert.deepEqual(
+  lint({
+    content: [
+      {
+        heading: 'Preamble',
+        form: {content: ['This is a preamble.']}
+      },
+      {
+        form: {content: ['Nothing important gets said in Preamble.']}
+      }
+    ]
+  }),
+  [
+    {
+      message: (
+        'The heading "Preamble" is used, ' +
+        'but not marked as a reference.'
+      ),
+      level: 'info',
+      path: ['content', 1, 'form', 'content', 0],
+      source: 'commonform-lint',
+      url: null
+    }
+  ],
+  'notes unmarked reference'
+)
+```

--- a/README.md
+++ b/README.md
@@ -201,3 +201,91 @@ assert.deepEqual(
   []
 )
 ```
+
+# Unmarked Defined Terms
+
+```javascript
+assert.deepEqual(
+  lint({
+    content: [
+      {
+        form: {
+          content: [
+            'Defines the term ', {definition: 'Agreement'}, '.'
+          ],
+        }
+      },
+      {
+        form: {
+          content: [
+            'Uses the term ', {use: 'Agreement'}, '.'
+          ],
+        }
+      },
+      {
+        form: {
+          content: [
+            'Uses the term ', {use: 'Agreement'}, ' again.'
+          ],
+        }
+      },
+      {
+        form: {
+          content: [
+            'Uses the term Agreement without marking.'
+          ],
+        }
+      }
+    ]
+  }),
+  [
+    {
+      message: 'The term "Agreement" is used, but not marked as a defined term.',
+      level: 'info',
+      path: ['content', 3, 'form', 'content', 0],
+      source: 'commonform-lint',
+      url: null
+    }
+  ],
+  'notes unmarked use of defined term'
+)
+```
+
+```javascript
+assert.deepEqual(
+  lint({
+    content: [
+      {
+        form: {
+          content: [
+            'Defines the term ', {definition: 'Apple'}, '.'
+          ],
+        }
+      },
+      {
+        form: {
+          content: [
+            'Uses the term ', {use: 'Apple'}, '.'
+          ],
+        }
+      },
+      {
+        form: {
+          content: [
+            'Uses the term ', {use: 'Apple'}, ' again.'
+          ],
+        }
+      },
+      {
+        form: {
+          content: [
+            'Uses Applesauce, which is not a defined term.'
+          ],
+        }
+      }
+    ]
+  }),
+  [],
+  'does not note unmarked use of defined term within a longer word'
+)
+```

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ var rules = [
   require('./rules/specific/undefined-terms'),
   require('./rules/specific/unused-terms'),
   require('./rules/specific/terms-used-once'),
-  require('./rules/specific/unmarked-terms')
+  require('./rules/specific/unmarked-terms'),
+  require('./rules/specific/unmarked-references')
 ]
 
 module.exports = function (form) {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ var rules = [
   require('./rules/specific/duplicate-headings'),
   require('./rules/specific/undefined-terms'),
   require('./rules/specific/unused-terms'),
-  require('./rules/specific/terms-used-once')
+  require('./rules/specific/terms-used-once'),
+  require('./rules/specific/unmarked-terms')
 ]
 
 module.exports = function (form) {

--- a/rules/abstract/unmarked.js
+++ b/rules/abstract/unmarked.js
@@ -1,0 +1,40 @@
+module.exports =
+function (namespace, messageFormat, level, form, analysis) {
+  var names = Object.keys(analysis[namespace])
+    .map(function (name) {
+      return {
+        name: name,
+        expression: new RegExp('\\b' + name + '\\b')
+      }
+    })
+  return recurse(form, [], messageFormat, names)
+}
+
+function recurse (form, path, messageFormat, names) {
+  return form.content.reduce(function (annotations, element, index) {
+    if (element.hasOwnProperty('form')) {
+      return annotations.concat(
+        recurse(
+          element.form,
+          path.concat('content', index, 'form'),
+          messageFormat,
+          names
+        )
+      )
+    } else if (typeof element === 'string') {
+      return names.reduce(function (annotations, definition) {
+        if (definition.expression.test(element)) {
+          return annotations.concat({
+            message: messageFormat.replace('%s', definition.name),
+            level: 'info',
+            path: path.concat('content', index)
+          })
+        } else {
+          return annotations
+        }
+      }, annotations)
+    } else {
+      return annotations
+    }
+  }, [])
+}

--- a/rules/specific/unmarked-references.js
+++ b/rules/specific/unmarked-references.js
@@ -1,0 +1,5 @@
+module.exports = require('../abstract/unmarked').bind(
+  this, 'headings',
+  'The heading "%s" is used, but not marked as a reference.',
+  'info'
+)

--- a/rules/specific/unmarked-terms.js
+++ b/rules/specific/unmarked-terms.js
@@ -1,0 +1,43 @@
+module.exports = function (form, analysis) {
+  var definitions = Object.keys(analysis.definitions)
+    .map(function (term) {
+      return {
+        term: term,
+        expression: new RegExp('\\b' + term + '\\b')
+      }
+    })
+  return recurse(form, [], definitions)
+}
+
+var MESSAGE_FORMAT = (
+  'The term "%s" is used, ' +
+  'but not marked as a defined term.'
+)
+
+function recurse (form, path, definitions) {
+  return form.content.reduce(function (annotations, element, index) {
+    if (element.hasOwnProperty('form')) {
+      return annotations.concat(
+        recurse(
+          element.form,
+          path.concat('content', index, 'form'),
+          definitions
+        )
+      )
+    } else if (typeof element === 'string') {
+      return definitions.reduce(function (annotations, definition) {
+        if (definition.expression.test(element)) {
+          return annotations.concat({
+            message: MESSAGE_FORMAT.replace('%s', definition.term),
+            level: 'info',
+            path: path.concat('content', index)
+          })
+        } else {
+          return annotations
+        }
+      }, annotations)
+    } else {
+      return annotations
+    }
+  }, [])
+}

--- a/rules/specific/unmarked-terms.js
+++ b/rules/specific/unmarked-terms.js
@@ -1,43 +1,5 @@
-module.exports = function (form, analysis) {
-  var definitions = Object.keys(analysis.definitions)
-    .map(function (term) {
-      return {
-        term: term,
-        expression: new RegExp('\\b' + term + '\\b')
-      }
-    })
-  return recurse(form, [], definitions)
-}
-
-var MESSAGE_FORMAT = (
-  'The term "%s" is used, ' +
-  'but not marked as a defined term.'
+module.exports = require('../abstract/unmarked').bind(
+  this, 'definitions',
+  'The term "%s" is used, but not marked as a defined term.',
+  'info'
 )
-
-function recurse (form, path, definitions) {
-  return form.content.reduce(function (annotations, element, index) {
-    if (element.hasOwnProperty('form')) {
-      return annotations.concat(
-        recurse(
-          element.form,
-          path.concat('content', index, 'form'),
-          definitions
-        )
-      )
-    } else if (typeof element === 'string') {
-      return definitions.reduce(function (annotations, definition) {
-        if (definition.expression.test(element)) {
-          return annotations.concat({
-            message: MESSAGE_FORMAT.replace('%s', definition.term),
-            level: 'info',
-            path: path.concat('content', index)
-          })
-        } else {
-          return annotations
-        }
-      }, annotations)
-    } else {
-      return annotations
-    }
-  }, [])
-}


### PR DESCRIPTION
cc @anseljh

This should help a bit when writing up forms as markup, or importing forms written as markup into commonform.org.